### PR TITLE
Add Google Webmaster site verification key

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,3 +14,6 @@ defaults:
       type: "bugzilla"
     values:
       layout: "bugzilla"
+
+webmaster_verifications:
+  google: "ED4N-AKhKPU0x6EQ_bMwQx6v_wH0eQn6FQm8szzaOzA"


### PR DESCRIPTION
This key will permit @IgnoredAmbience to view the Google Indexing logs
and Search Analytics for the tc39.github.io/archives/ website. This is
to address the lack of indexing currently experienced of the bugzilla
archives.

References #7